### PR TITLE
Sub-ticket [COSMIC-353]: Modify CoSMIC final payload format to use generated value for `inquiry_cycle_id` key from FE before sending to the database [COSMIC-294]

### DIFF
--- a/backend/routers/cosmic.py
+++ b/backend/routers/cosmic.py
@@ -31,6 +31,7 @@ from ...utils.chat_history import build_context_from_messages
 from ...utils.log_tool import set_color
 
 
+
 router: APIRouter = APIRouter(
     prefix="/api/v1/cosmic",
     tags=[APITag.cosmic]
@@ -51,9 +52,11 @@ class Message(BaseModel):
 
 
 class User(BaseModel):
-    id:     str
-    role:   str
-    email:  str
+    id:                 str
+    role:               str
+    email:              str
+    inquiry_cycle_id:   str
+
 
 
 class Body(BaseModel):
@@ -144,9 +147,11 @@ async def process_cosmic(
     opensi_cosmic:      OpenSICoSMIC = Depends(get_opensi_cosmic)
 ):
     try:
-        user_id:    str     = data.body.model_dump(mode="json")["user"]["id"]
+        user_id:            str = data.body.model_dump(mode="python")["user"]["id"]
         # user_role:  str     = data.body.model_dump(mode="json")["user"]["role"]
         # user_email: str     = data.body.model_dump(mode="json")["user"]["email"]
+        inquiry_cycle_id:   str = data.body.model_dump(mode="python")["user"]["inquiry_cycle_id"]
+
 
         chat_history_context: str = build_context_from_messages(
             messages=data.body.model_dump(mode="json").get(
@@ -240,6 +245,7 @@ async def process_cosmic(
         llm_response_timestamp: str = datetime.now(tz=timezone.utc).isoformat()
 
         new_detail: dict[str, str | int] = {
+            "inquiry_cycle_id":     str(inquiry_cycle_id),
             "user_role":            "user",         # per agreed solution within our team
             "user_query":           raw_user_message,
             "query_create_on":      user_query_timestamp,


### PR DESCRIPTION
> [!NOTE]
> Ref:
> 1. _**Parent ticket**: [COSMIC-294](https://opensi.atlassian.net/browse/COSMIC-294)_
> 2. _**Sub ticket**: [COSMIC-353](https://opensi.atlassian.net/browse/COSMIC-353)_


**Extra information besides what have been explained in both tickets:**
> [!CAUTION]
> Make sure to test run this PR with [sub-ticket 352](https://github.com/TheOpenSI/CoSMIC_UI/pull/65) & [sub-ticket 319](https://github.com/TheOpenSI/CoSMIC_DB/pull/66). This's because the new `inquiry_cycle_id` field is implemented from **CoSMIC_DB**.

[COSMIC-294]: https://opensi.atlassian.net/browse/COSMIC-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[COSMIC-353]: https://opensi.atlassian.net/browse/COSMIC-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ